### PR TITLE
Add planned and expected balance calculations

### DIFF
--- a/MoneyApp.Module/BusinessObjects/Buchung.cs
+++ b/MoneyApp.Module/BusinessObjects/Buchung.cs
@@ -101,6 +101,14 @@ namespace MoneyApp.Module.BusinessObjects
             protected set => SetPropertyValue(nameof(Saldo), ref saldo, value);
         }
 
+        private decimal saldoGeplant;
+        [Persistent]
+        public decimal SaldoGeplant
+        {
+            get => saldoGeplant;
+            protected set => SetPropertyValue(nameof(SaldoGeplant), ref saldoGeplant, value);
+        }
+
         protected override void OnSaving()
         {
             base.OnSaving();
@@ -112,12 +120,23 @@ namespace MoneyApp.Module.BusinessObjects
                     Position = (maxPos is int ? (int)maxPos : 0) + 1;
                 }
 
-                decimal sum = 0m;
+                decimal sumErledigt = 0m;
+                decimal sumGeplant = 0m;
                 foreach (Buchung buchung in Konto.Buchungen)
                 {
-                    sum += buchung == this ? Betrag : buchung.Betrag;
+                    var typ = buchung == this ? Typ : buchung.Typ;
+                    var betrag = buchung == this ? Betrag : buchung.Betrag;
+                    if (typ == Buchungstyp.Erledigt)
+                    {
+                        sumErledigt += betrag;
+                    }
+                    if (typ == Buchungstyp.Erledigt || typ == Buchungstyp.Geplant)
+                    {
+                        sumGeplant += betrag;
+                    }
                 }
-                Saldo = sum;
+                Saldo = sumErledigt;
+                SaldoGeplant = sumGeplant;
             }
         }
 

--- a/MoneyApp.Module/BusinessObjects/Konto.cs
+++ b/MoneyApp.Module/BusinessObjects/Konto.cs
@@ -50,5 +50,11 @@ namespace MoneyApp.Module.BusinessObjects
         {
             get => GetCollection<Buchung>(nameof(Buchungen));
         }
+
+        [NonPersistent]
+        public decimal Saldo => Buchungen.Where(b => b.Typ == Buchungstyp.Erledigt).Sum(b => b.Betrag);
+
+        [NonPersistent]
+        public decimal SaldoErwartet => Buchungen.Where(b => b.Typ == Buchungstyp.Erledigt || b.Typ == Buchungstyp.Geplant).Sum(b => b.Betrag);
     }
 }


### PR DESCRIPTION
## Summary
- track both executed and planned sums per booking
- expose account balance and expected balance from bookings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e6e13716c832780c56c0c52e38fb4