### PR TITLE
feat: add bulk booking creation

### DIFF
--- a/MoneyApp.Module/BusinessObjects/Konto.cs
+++ b/MoneyApp.Module/BusinessObjects/Konto.cs
@@ -56,5 +56,19 @@ namespace MoneyApp.Module.BusinessObjects
 
         [NonPersistent]
         public decimal SaldoErwartet => Buchungen.Where(b => b.Typ == Buchungstyp.Erledigt || b.Typ == Buchungstyp.Geplant).Sum(b => b.Betrag);
+
+        public void ErzeugeBuchungen(int anzahl, int intervallMonate, Buchungstyp status)
+        {
+            for (int i = 0; i < anzahl; i++)
+            {
+                var buchung = new Buchung(Session)
+                {
+                    Konto = this,
+                    Datum = DateTime.Today.AddMonths(i * intervallMonate),
+                    Typ = status,
+                    Zweck = $"Automatische Buchung {i + 1}"
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ErzeugeBuchungen` method to `Konto` to generate multiple bookings across a month interval with a given status

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e72f97e0483278736dfe62dfedc44